### PR TITLE
Correção boleto Banrisul

### DIFF
--- a/src/Boleto/Banco/Banrisul.php
+++ b/src/Boleto/Banco/Banrisul.php
@@ -185,4 +185,26 @@ class Banrisul extends AbstractBoleto implements BoletoContract
 
         return $codigoCliente;
     }
+
+    /**
+     * Define um array com instruções (máximo 8) para pagamento (método na super classe)
+     * Adiciona a instrução de impago no array de instruções
+     *
+     * @param array $instrucoes
+     *
+     * @return AbstractBoleto
+     * @throws \Exception
+     */
+    public function setInstrucoes(array $instrucoes)
+    {
+        if (count($instrucoes) > 8) {
+            throw new \Exception('Máximo de 8 instruções.');
+        }
+
+        $this->instrucoes = $instrucoes;
+
+        $this->addInstrucao('Devolver se impago após 60 dias do vencimento');
+
+        return $this;
+    }
 }

--- a/src/Cnab/Remessa/Cnab400/Banco/Banrisul.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Banrisul.php
@@ -250,7 +250,7 @@ class Banrisul extends AbstractRemessa implements RemessaContract
         $this->add(31, 37, '');
         $this->add(38, 62, Util::formatCnab('X', $boleto->getNumeroControle(), 25));
         $this->add(63, 72, Util::formatCnab('9L', $boleto->getNossoNumero(), 10));
-        $this->add(73, 104, '');
+        $this->add(73, 104, Util::formatCnab('X', $boleto->getInstrucoes()[0], 32));
         $this->add(105, 107, '');
         $this->add(108, 108, Util::formatCnab('X', $this->getCarteiraNumero(), 1));
         $this->add(109, 110, self::OCORRENCIA_REMESSA); // REGISTRO


### PR DESCRIPTION
O boleto banrisul estava desatualizado, e o banco acusou algumas alterações a serem feitas.
Card relacionado: https://app.pipefy.com/open-cards/424015678